### PR TITLE
Template edit & delete buttons security

### DIFF
--- a/src/core/auth/Guard.tsx
+++ b/src/core/auth/Guard.tsx
@@ -21,9 +21,9 @@ namespace Guard {
     children: JSX.Element | Children.RenderProp;
   }
 
-  export interface AuthorProps extends Props {
-    children: JSX.Element | null;
-    author: string  
+  export interface AuthorProps {
+    children: JSX.Element;
+    author: string;
   }
 }
 
@@ -80,10 +80,8 @@ const UnprotectedRoute = ({ component: Component, redirect, ...rest }: Guard.Rou
 const OnlyAuthor = ({ children, author }: Guard.AuthorProps) => {
   const { user } = useAuthProvider();
 
-  return user && user.username === author
-  ? children
-  : null
-}
+  return user && user.username === author ? children : null;
+};
 
 const Guard = {
   Protected,

--- a/src/core/auth/Guard.tsx
+++ b/src/core/auth/Guard.tsx
@@ -22,8 +22,8 @@ namespace Guard {
   }
 
   export interface AuthorProps extends Props {
-    author: string,
-    redirect?: string
+    children: JSX.Element | null;
+    author: string  
   }
 }
 
@@ -77,20 +77,12 @@ const UnprotectedRoute = ({ component: Component, redirect, ...rest }: Guard.Rou
   );
 };
 
-const OnlyAuthor = ({children, author, redirect}: Guard.AuthorProps) => {
-  const { pending, authorized, user, ...state } = useAuthProvider();
+const OnlyAuthor = ({ children, author }: Guard.AuthorProps) => {
+  const { user } = useAuthProvider();
 
-  return !user
-  ? null
-  : pending
-  ? null
-  : authorized && author === user.username
-  ? typeof children === 'function'
-    ? children({user, ...state})
-    : children
-  : redirect
-  ? <Redirect to={redirect} />
-  : null;
+  return user && user.username === author
+  ? children
+  : null
 }
 
 const Guard = {

--- a/src/core/auth/Guard.tsx
+++ b/src/core/auth/Guard.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType, Component } from 'react';
+import React, { ComponentType } from 'react';
 import { Route, Redirect, RouteProps } from 'react-router';
 
 import AuthProvider, { useAuthProvider } from './AuthProvider';
@@ -79,7 +79,7 @@ const UnprotectedRoute = ({ component: Component, redirect, ...rest }: Guard.Rou
 
 const OnlyAuthor = ({children, author, redirect}: Guard.AuthorProps) => {
   const { pending, authorized, user, ...state } = useAuthProvider();
-  
+
   return !user
   ? null
   : pending
@@ -92,8 +92,6 @@ const OnlyAuthor = ({children, author, redirect}: Guard.AuthorProps) => {
   ? <Redirect to={redirect} />
   : null;
 }
-
-
 
 const Guard = {
   Protected,

--- a/src/core/auth/Guard.tsx
+++ b/src/core/auth/Guard.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from 'react';
+import React, { ComponentType, Component } from 'react';
 import { Route, Redirect, RouteProps } from 'react-router';
 
 import AuthProvider, { useAuthProvider } from './AuthProvider';
@@ -19,6 +19,11 @@ namespace Guard {
 
   export interface Props {
     children: JSX.Element | Children.RenderProp;
+  }
+
+  export interface AuthorProps extends Props {
+    author: string,
+    redirect?: string
   }
 }
 
@@ -72,11 +77,30 @@ const UnprotectedRoute = ({ component: Component, redirect, ...rest }: Guard.Rou
   );
 };
 
+const OnlyAuthor = ({children, author, redirect}: Guard.AuthorProps) => {
+  const { pending, authorized, user, ...state } = useAuthProvider();
+  
+  return !user
+  ? null
+  : pending
+  ? null
+  : authorized && author === user.username
+  ? typeof children === 'function'
+    ? children({user, ...state})
+    : children
+  : redirect
+  ? <Redirect to={redirect} />
+  : null;
+}
+
+
+
 const Guard = {
   Protected,
   Unprotected,
   ProtectedRoute,
-  UnprotectedRoute
+  UnprotectedRoute,
+  OnlyAuthor
 };
 
 export default Guard;

--- a/src/modules/template-details/TemplateDetails.tsx
+++ b/src/modules/template-details/TemplateDetails.tsx
@@ -11,9 +11,9 @@ import ShareIcon from '@material-ui/icons/Share';
 
 import { Button, Loader, More } from 'ui';
 
-import { useAuthProvider } from 'core/auth';
-
 import { convertNumberToKFormat, convertDate } from 'utils';
+
+import { Guard } from 'core/auth';
 
 import { TemplateTags } from 'shared/components';
 
@@ -33,8 +33,6 @@ const TemplateDetails = ({ match }: TemplateDetails.Props) => {
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
 
   const { template, loading, getTemplateDetails } = useTemplateDetailsProvider();
-
-  const { user, authorized } = useAuthProvider();
 
   useEffect(() => {
     getTemplateDetails(match.params.id);
@@ -71,7 +69,7 @@ const TemplateDetails = ({ match }: TemplateDetails.Props) => {
                   <ShareIcon /> SOURCE
                 </Button>
               </Link>
-              {user !== null && authorized && template.addedBy === user.username ? (
+              <Guard.OnlyAuthor author={template.addedBy}>
                 <More>
                   <NavLink to={`/app/templates/management/${match.params.id}`} className={csx.edit}>
                     <EditIcon />
@@ -82,7 +80,7 @@ const TemplateDetails = ({ match }: TemplateDetails.Props) => {
                     DELETE
                   </div>
                 </More>
-              ) : null}
+                </Guard.OnlyAuthor>
             </div>
 
             <section>

--- a/src/modules/template-details/TemplateDetails.tsx
+++ b/src/modules/template-details/TemplateDetails.tsx
@@ -11,6 +11,8 @@ import ShareIcon from '@material-ui/icons/Share';
 
 import { Button, Loader, More } from 'ui';
 
+import { useAuthProvider } from 'core/auth';
+
 import { convertNumberToKFormat, convertDate } from 'utils';
 
 import { TemplateTags } from 'shared/components';
@@ -18,8 +20,6 @@ import { TemplateTags } from 'shared/components';
 import TemplateDetailsProvider, {
   useTemplateDetailsProvider
 } from 'shared/providers/template-details';
-
-import { useAuthProvider } from 'core/auth';
 
 import ConfirmDelete from './confirm-delete';
 

--- a/src/modules/template-details/TemplateDetails.tsx
+++ b/src/modules/template-details/TemplateDetails.tsx
@@ -19,6 +19,8 @@ import TemplateDetailsProvider, {
   useTemplateDetailsProvider
 } from 'shared/providers/template-details';
 
+import { useAuthProvider } from '../../core/auth';
+
 import ConfirmDelete from './confirm-delete';
 
 import csx from './TemplateDetails.scss';
@@ -31,6 +33,8 @@ const TemplateDetails = ({ match }: TemplateDetails.Props) => {
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
 
   const { template, loading, getTemplateDetails } = useTemplateDetailsProvider();
+
+  const { user, authorized } = useAuthProvider();
 
   useEffect(() => {
     getTemplateDetails(match.params.id);
@@ -67,17 +71,18 @@ const TemplateDetails = ({ match }: TemplateDetails.Props) => {
                   <ShareIcon /> SOURCE
                 </Button>
               </Link>
-
-              <More>
-                <NavLink to={`/app/templates/management/${match.params.id}`} className={csx.edit}>
-                  <EditIcon />
-                  EDIT
-                </NavLink>
-                <div className={csx.delete} onClick={openConfirmDelete}>
-                  <DeleteIcon />
-                  DELETE
-                </div>
-              </More>
+              {user !== null && authorized && template.addedBy === user.username ? (
+                <More>
+                  <NavLink to={`/app/templates/management/${match.params.id}`} className={csx.edit}>
+                    <EditIcon />
+                    EDIT
+                  </NavLink>
+                  <div className={csx.delete} onClick={openConfirmDelete}>
+                    <DeleteIcon />
+                    DELETE
+                  </div>
+                </More>
+              ) : null}
             </div>
 
             <section>

--- a/src/modules/template-details/TemplateDetails.tsx
+++ b/src/modules/template-details/TemplateDetails.tsx
@@ -19,7 +19,7 @@ import TemplateDetailsProvider, {
   useTemplateDetailsProvider
 } from 'shared/providers/template-details';
 
-import { useAuthProvider } from '../../core/auth';
+import { useAuthProvider } from 'core/auth';
 
 import ConfirmDelete from './confirm-delete';
 

--- a/src/modules/template-management/TemplateManagement.tsx
+++ b/src/modules/template-management/TemplateManagement.tsx
@@ -28,7 +28,7 @@ const TemplateManagement = () => {
   const loading = loadingPatterns || loadingTechnologies || loadingConfig;
 
   return (
-    template && <Guard.OnlyAuthor author={template.addedBy} redirect='/'>
+    template && <Guard.OnlyAuthor author={template.addedBy}>
       <div className={csx.templateManagement}>
       {loading ? <Loader /> : <TemplateForm config={config} />}
     </div>

--- a/src/modules/template-management/TemplateManagement.tsx
+++ b/src/modules/template-management/TemplateManagement.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import { Redirect } from 'react-router';
 
 import { Loader } from 'ui';
 
 import { usePatternsProvider } from 'core/patterns';
 import { useTechnologiesProvider } from 'core/technologies';
-import { useAuthProvider } from 'core/auth';
+import { Guard } from 'core/auth';
 
 import TemplateDetailsProvider, {
   useTemplateDetailsProvider
@@ -24,21 +23,17 @@ const TemplateManagement = () => {
 
   const { template } = useTemplateDetailsProvider();
 
-  const {
-    user: { username }
-  } = useAuthProvider();
-
   const { loading: loadingConfig, config } = useTemplateManagementConfig();
 
   const loading = loadingPatterns || loadingTechnologies || loadingConfig;
 
-  return template !== null && template.addedBy !== username ? (
-    <Redirect to="/" />
-  ) : (
-    <div className={csx.templateManagement}>
+  return (
+    template && <Guard.OnlyAuthor author={template.addedBy} redirect='/'>
+      <div className={csx.templateManagement}>
       {loading ? <Loader /> : <TemplateForm config={config} />}
     </div>
-  );
+    </Guard.OnlyAuthor>
+  )
 };
 
 export default () => (

--- a/src/modules/template-management/TemplateManagement.tsx
+++ b/src/modules/template-management/TemplateManagement.tsx
@@ -5,7 +5,7 @@ import { Loader } from 'ui';
 
 import { usePatternsProvider } from 'core/patterns';
 import { useTechnologiesProvider } from 'core/technologies';
-import { useAuthProvider } from '../../core/auth';
+import { useAuthProvider } from 'core/auth';
 
 import TemplateDetailsProvider, {
   useTemplateDetailsProvider

--- a/src/modules/template-management/TemplateManagement.tsx
+++ b/src/modules/template-management/TemplateManagement.tsx
@@ -1,11 +1,15 @@
 import React from 'react';
+import { Redirect } from 'react-router';
 
 import { Loader } from 'ui';
 
 import { usePatternsProvider } from 'core/patterns';
 import { useTechnologiesProvider } from 'core/technologies';
+import { useAuthProvider } from '../../core/auth';
 
-import TemplateDetailsProvider from 'shared/providers/template-details';
+import TemplateDetailsProvider, {
+  useTemplateDetailsProvider
+} from 'shared/providers/template-details';
 
 import TemplateForm from './template-form';
 
@@ -18,11 +22,19 @@ const TemplateManagement = () => {
 
   const { loading: loadingPatterns } = usePatternsProvider();
 
+  const { template } = useTemplateDetailsProvider();
+
+  const {
+    user: { username }
+  } = useAuthProvider();
+
   const { loading: loadingConfig, config } = useTemplateManagementConfig();
 
   const loading = loadingPatterns || loadingTechnologies || loadingConfig;
 
-  return (
+  return template !== null && template.addedBy !== username ? (
+    <Redirect to="/" />
+  ) : (
     <div className={csx.templateManagement}>
       {loading ? <Loader /> : <TemplateForm config={config} />}
     </div>


### PR DESCRIPTION
added some logic behind edit/delete template buttons ("More" button) - only authenticated and authorized (owners of template) users can edit or delete templates.
for now if you want to force to edit template by url it redirect you to '/' - im not sure if this is good solution.
