### PR TITLE
bugfix/search-area-outline

### DIFF
--- a/src/ui/select-base/SelectBase.scss
+++ b/src/ui/select-base/SelectBase.scss
@@ -2,8 +2,10 @@
 
 .search {
   @include row;
+  @include noSelect;
   padding: 0 20px;
   border-bottom: 1px solid rgba($primary, 0.43);
+  outline: none;
 
   & > input {
     @include label;


### PR DESCRIPTION
Search area outline bug on click fixed. Also added noSelect mixin to input so that placeholder is not selectable any longer after double click.