### PR TITLE
feature/change-error-display

### DIFF
--- a/src/core/api/alerts-manager/AlertsManager.tsx
+++ b/src/core/api/alerts-manager/AlertsManager.tsx
@@ -5,29 +5,19 @@ import { Alert } from 'ui';
 import { core } from '..';
 
 const AlertsManager = () => {
-  const [alerts, setAlerts] = useState<string[]>([]);
+  const [alert, setAlert] = useState('');
 
-  const closeAlert: Alert.OnClose = useCallback((idx) => {
-    setAlerts((prevAlerts) => prevAlerts.filter((_, aIdx) => aIdx !== idx));
+  const closeAlert = useCallback(() => {
+    setAlert('');
   }, []);
 
   useEffect(() => {
-    const addAlert = (err: string) => {
-      setAlerts((prevAlerts) => [...prevAlerts, err]);
-    };
-
-    core.subscribe(addAlert);
+    core.subscribe(setAlert);
 
     return core.unsubscribe;
   }, []);
 
-  return (
-    <>
-      {alerts.map((alert, idx) => (
-        <Alert key={idx} idx={idx} message={alert} type="error" onClose={closeAlert} />
-      ))}
-    </>
-  );
+  return alert ? <Alert message={alert} onClose={closeAlert} /> : null;
 };
 
 export default AlertsManager;

--- a/src/ui/alert/Alert.scss
+++ b/src/ui/alert/Alert.scss
@@ -1,25 +1,17 @@
 @import 'styles/mixins';
 
 .alert {
-  @include rowBetween;
+  @include centered;
+  @include label;
   padding: 10px;
-
-  & > span {
-    @include label;
-    margin: 0 auto;
-  }
-
-  & > svg {
-    opacity: 0.8;
-    cursor: pointer;
-
-    &:hover {
-      opacity: 1;
-    }
-  }
+  width: 100%;
 
   &.error {
     background: $error;
     color: $white;
   }
+}
+
+.root {
+  width: 100%;
 }

--- a/src/ui/alert/Alert.scss
+++ b/src/ui/alert/Alert.scss
@@ -1,8 +1,6 @@
 @import 'styles/mixins';
 
 .alert {
-  @include centered;
-  @include label;
   padding: 10px;
   width: 100%;
 
@@ -10,8 +8,19 @@
     background: $error;
     color: $white;
   }
-}
 
-.root {
-  width: 100%;
+  & > div {
+    @include label;
+    @include noSelect;
+  }
+
+  .closeBtn {
+    height: 40px;
+    width: 40px;
+
+    svg {
+      font-size: 20px;
+      color: $white;
+    }
+  }
 }

--- a/src/ui/alert/Alert.tsx
+++ b/src/ui/alert/Alert.tsx
@@ -1,41 +1,36 @@
-import React, { useCallback, memo } from 'react';
+import React, { useCallback, memo, useState } from 'react';
 
-import CloseIcon from '@material-ui/icons/Close';
-
-import { usePortal } from 'utils';
+import Snackbar from '@material-ui/core/Snackbar';
 
 import csx from './Alert.scss';
 
 namespace Alert {
-  export namespace Events {
-    export type Close = React.MouseEvent<SVGSVGElement, MouseEvent>;
-  }
-
   export type Types = 'warning' | 'error' | 'success' | 'info';
 
-  export type OnClose = (idx: number) => void;
-
   export interface Props {
-    idx: number;
     message: string;
     type?: Types;
-    onClose: OnClose;
+    onClose: () => void;
   }
 }
 
 const Alert = memo(
-  ({ idx, message, type = 'error', onClose }: Alert.Props) => {
-    const render = usePortal();
+  ({ message, type = 'error', onClose }: Alert.Props) => {
+    const [isOpen, setIsOpen] = useState(true);
 
-    const handleClose = useCallback((e: Alert.Events.Close) => {
-      onClose(+e.currentTarget.getAttribute('data-idx'));
+    const handleClose = useCallback(() => {
+      setIsOpen(false);
+      onClose();
     }, []);
 
-    return render(
-      <div className={`${csx.alert} ${csx[type]}`}>
-        <span>{message}</span>
-        <CloseIcon data-idx={idx} onClick={handleClose} />
-      </div>
+    return (
+      <Snackbar
+        open={isOpen}
+        onClose={handleClose}
+        message={message}
+        classes={{ root: `${csx.root}` }}
+        ContentProps={{ classes: { root: `${csx.alert} ${csx[type]}` } }}
+      />
     );
   },
   () => true

--- a/src/ui/alert/Alert.tsx
+++ b/src/ui/alert/Alert.tsx
@@ -1,6 +1,9 @@
-import React, { useCallback, memo, useState } from 'react';
+import React, { useCallback, useState, memo } from 'react';
 
 import Snackbar from '@material-ui/core/Snackbar';
+import CloseIcon from '@material-ui/icons/Close';
+
+import { Button } from '..';
 
 import csx from './Alert.scss';
 
@@ -10,26 +13,34 @@ namespace Alert {
   export interface Props {
     message: string;
     type?: Types;
-    onClose: () => void;
+    onClose(): void;
   }
 }
 
 const Alert = memo(
   ({ message, type = 'error', onClose }: Alert.Props) => {
-    const [isOpen, setIsOpen] = useState(true);
+    const [open, setOpen] = useState(true);
 
     const handleClose = useCallback(() => {
-      setIsOpen(false);
+      setOpen(false);
       onClose();
     }, []);
 
     return (
       <Snackbar
-        open={isOpen}
-        onClose={handleClose}
+        open={open}
         message={message}
-        classes={{ root: `${csx.root}` }}
         ContentProps={{ classes: { root: `${csx.alert} ${csx[type]}` } }}
+        action={
+          <Button
+            className={csx.closeBtn}
+            variant="icon"
+            theme="primaryTransparent"
+            onClick={handleClose}
+          >
+            <CloseIcon />
+          </Button>
+        }
       />
     );
   },


### PR DESCRIPTION
- Changed alert implementation to Material UI Snackbar. 
- Code cleanup, since only one error can be displayed at the time we dont need an array with mapping and filtering anymore. 
- Fixed bug where alert was still visible even though the url has changed.