### PR TITLE
remove-dashboard-and-projects-urls

### DIFF
--- a/src/modules/main/Main.tsx
+++ b/src/modules/main/Main.tsx
@@ -38,10 +38,6 @@ const Main = ({ match }: RouteChildrenProps) => {
             component={Admin}
           />
 
-          <Route exact path={`${match.path}/dashboard`} render={() => <div>dashboard</div>} />
-
-          <Route exact path={`${match.path}/projects`} render={() => <div>projects</div>} />
-
           <Guard.ProtectedRoute
             exact
             redirect={`${match.path}/templates`}
@@ -65,7 +61,7 @@ const Main = ({ match }: RouteChildrenProps) => {
             component={TemplateDocumentation}
           />
 
-          <Route path="*" render={() => <Redirect to={`${match.path}/dashboard`} />} />
+          <Route path="*" render={() => <Redirect to={`${match.path}/templates/all`} />} />
         </Switch>
       </main>
     </div>

--- a/src/modules/main/sidebar/sidebar-links/SidebarLinks.tsx
+++ b/src/modules/main/sidebar/sidebar-links/SidebarLinks.tsx
@@ -2,8 +2,6 @@ import React from 'react';
 import { NavLink, useLocation, useRouteMatch } from 'react-router-dom';
 
 import AdminIcon from '@material-ui/icons/SupervisorAccount';
-import DashboardIcon from '@material-ui/icons/Dashboard';
-import ProjectsIcon from '@material-ui/icons/Work';
 import TemplatesIcon from '@material-ui/icons/LibraryBooks';
 
 import { Guard } from 'core/auth';
@@ -29,28 +27,11 @@ const SidebarLinks = ({ renderLink }: SidebarLinks.Props) => {
   return (
     <div className={csx.links}>
       <NavLink
-        exact
-        activeClassName={getActiveClassName(pathname, 'dashboard')}
-        className={csx.link}
-        to={`${path}/dashboard`}
-      >
-        {renderLink(<DashboardIcon />, 'Dashboard')}
-      </NavLink>
-
-      <NavLink
         activeClassName={getActiveClassName(pathname, 'templates')}
         className={csx.link}
         to={`${path}/templates`}
       >
         {renderLink(<TemplatesIcon />, 'Templates')}
-      </NavLink>
-
-      <NavLink
-        activeClassName={getActiveClassName(pathname, 'projects')}
-        className={csx.link}
-        to={`${path}/projects`}
-      >
-        {renderLink(<ProjectsIcon />, 'Projects')}
       </NavLink>
 
       <Guard.Admin>


### PR DESCRIPTION
Removed dashboard and projects urls from sidebar. Default route now redirects to all templates.